### PR TITLE
Simplify devcontainer SignalR server to minimal .NET hub

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "name": "signalRClient",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "forwardPorts": [8080],
+  "shutdownAction": "stopCompose"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/java:17
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity
+    networks:
+      - dev
+  signalr-server:
+    build:
+      context: ./signalr-server
+    ports:
+      - "8080:8080"
+    networks:
+      - dev
+networks:
+  dev:
+    driver: bridge

--- a/.devcontainer/signalr-server/Dockerfile
+++ b/.devcontainer/signalr-server/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY SignalRServer.csproj .
+RUN dotnet restore
+COPY . .
+RUN dotnet publish -c Release -o /app
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
+WORKDIR /app
+COPY --from=build /app .
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "SignalRServer.dll"]

--- a/.devcontainer/signalr-server/Program.cs
+++ b/.devcontainer/signalr-server/Program.cs
@@ -16,12 +16,14 @@ _ = Task.Run(async () =>
 {
     while (true)
     {
-        await Task.Delay(TimeSpan.FromSeconds(random.Next(2, 5)));
-        await hubContext.Clients.All.SendAsync("EventA", Guid.NewGuid().ToString());
-        await hubContext.Clients.All.SendAsync("EventB", Guid.NewGuid().ToString());
+        await Task.Delay(TimeSpan.FromSeconds(random.Next(1, 5)));
+        await hubContext.Clients.All.SendAsync("EventA","EventA"+ Guid.NewGuid().ToString());
+        await Task.Delay(TimeSpan.FromSeconds(random.Next(1, 2)));
+        await hubContext.Clients.All.SendAsync("EventB","EventB"+ Guid.NewGuid().ToString());
     }
 });
 
 app.Run("http://0.0.0.0:8080");
 
 class TestHub : Hub { }
+

--- a/.devcontainer/signalr-server/Program.cs
+++ b/.devcontainer/signalr-server/Program.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddSignalR();
+
+var app = builder.Build();
+app.MapHub<TestHub>("/hub");
+
+var hubContext = app.Services.GetRequiredService<IHubContext<TestHub>>();
+var random = new Random();
+_ = Task.Run(async () =>
+{
+    while (true)
+    {
+        await Task.Delay(TimeSpan.FromSeconds(random.Next(2, 5)));
+        await hubContext.Clients.All.SendAsync("EventA", Guid.NewGuid().ToString());
+        await hubContext.Clients.All.SendAsync("EventB", Guid.NewGuid().ToString());
+    }
+});
+
+app.Run("http://0.0.0.0:8080");
+
+class TestHub : Hub { }

--- a/.devcontainer/signalr-server/SignalRServer.csproj
+++ b/.devcontainer/signalr-server/SignalRServer.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ replay_pid*
 # Gradle
 .gradle/
 build/
+
+# .NET build outputs
+bin/
+obj/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,17 @@ The jar is created at `build/libs/signarRSubscribe.jar`.
 
 ## Run
 ```
-java -jar build/libs/signarRSubscribe.jar <url> events=EventA,EventB
+java -jar build/libs/signarRSubscribe.jar http://localhost:8080/hub events=EventA,EventB
 ```
-- `<url>`: SignalR hub URL
-- `events=...`: comma-separated list of event names
+- `http://localhost:8080/hub`: URL of the test hub exposed by the dev container
+- `events=...`: comma-separated list of event names to subscribe to
+
+## Development container
+
+This project includes a VS Code [dev container](https://containers.dev/) setup
+that runs a lightweight .NET SignalR server for testing. The server exposes a
+hub at `/hub` on port `8080` and broadcasts `EventA` and `EventB` events with
+random strings every 2–5 seconds.
+
+The development environment is defined in `.devcontainer/` and can be used with
+the VS Code Dev Containers extension or GitHub Codespaces.


### PR DESCRIPTION
## Summary
- broadcast random text on events `EventA` and `EventB` for easier client testing
- document new event names in README example and devcontainer description

## Testing
- `gradle test`
- `dotnet build .devcontainer/signalr-server/SignalRServer.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c147c7d6bc83209f55b0cd1c073736